### PR TITLE
Import without unnecessarily deleting resources

### DIFF
--- a/swe1r/general.py
+++ b/swe1r/general.py
@@ -2,11 +2,13 @@ import struct
 from ..utils import clamp
 
 # 'bswe1r' for 'blender swe1r'
-# NOTE: use 3-letter code for data_type
+# NOTE: use 3-letter code for data_type and group_id
 data_name_prefix_short = 'bswe1r_'
 data_name_prefix_short_len = 7
 data_name_format = 'bswe1r_{data_type}_{label}'
 data_name_prefix_len = 11
+data_name_format_long = 'bswe1r_{data_type}_{group_id}_{label}'
+data_name_format_long_len = 15
 
 def readUInt8(buffer, cursor):
     return int.from_bytes(buffer[cursor: cursor+1], byteorder='big')

--- a/swe1r/general.py
+++ b/swe1r/general.py
@@ -3,6 +3,8 @@ from ..utils import clamp
 
 # 'bswe1r' for 'blender swe1r'
 # NOTE: use 3-letter code for data_type
+data_name_prefix_short = 'bswe1r_'
+data_name_prefix_short_len = 7
 data_name_format = 'bswe1r_{data_type}_{label}'
 data_name_prefix_len = 11
 

--- a/swe1r/general.py
+++ b/swe1r/general.py
@@ -1,6 +1,11 @@
 import struct
 from ..utils import clamp
 
+# 'bswe1r' for 'blender swe1r'
+# NOTE: use 3-letter code for data_type
+data_name_format = 'bswe1r_{data_type}_{label}'
+data_name_prefix_len = 11
+
 def readUInt8(buffer, cursor):
     return int.from_bytes(buffer[cursor: cursor+1], byteorder='big')
 

--- a/swe1r/modelblock.py
+++ b/swe1r/modelblock.py
@@ -238,7 +238,7 @@ class CollisionTrigger(DataStruct):
         
         self.flags.make(trigger_empty)
         trigger_empty['target'] = self.target
-        #TODO this needs to be able to select targets that aren't made yet
+        # TODO: this needs to be able to select targets that aren't made yet
         if self.target and '{:07d}'.format(self.target) in bpy.data.objects:
             trigger_empty.target = bpy.data.objects['{:07d}'.format(self.target)]
         
@@ -970,12 +970,9 @@ class MaterialTexture(DataStruct):
         self.unk6 = min(65535, self.height * 512)
         self.chunks.append(MaterialTextureChunk(self, self.model).unmake(self)) #this struct is required
         
-        # TODO: cleanup
         if image.name in self.model.written_textures:
             self.tex_index = image.name[data_name_prefix_len:]
             self.id = image.name[data_name_prefix_len:]
-            #self.tex_index = self.model.written_textures[image.name]
-            #self.id = self.model.written_textures[image.name]
         elif self.model.texture_export:
             texture = Texture(self.id).unmake(image)
             pixel_buffer = texture.pixels.write()
@@ -1099,9 +1096,7 @@ class Material(DataStruct):
         self.detect_skybox()
         return self
         
-    # TODO: cleanup
     def make(self):
-        #mat_name = str(self.id)
         mat_name = data_name_format_long.format(data_type = 'mat', group_id = '{:03d}'.format(self.model.id), label = str(self.id))
         if (self.texture is not None):
             material = bpy.data.materials.get(mat_name)
@@ -1130,10 +1125,10 @@ class Material(DataStruct):
             material.node_tree.links.new(node_3.outputs["Color"], material.node_tree.nodes['Principled BSDF'].inputs["Base Color"])
             material.node_tree.links.new(node_1.outputs["Alpha"], material.node_tree.nodes['Principled BSDF'].inputs["Alpha"])
             material.node_tree.nodes["Principled BSDF"].inputs["Specular IOR Level"].default_value = 0
-            #image = str(self.texture.tex_index)
+
             tex_name = data_name_format.format(data_type = 'tex', label = str(self.texture.tex_index))
-            # NOTE: probably shouldn't do it this way; TODO find specific tag
-            #if image in ["1167", "1077", "1461", "1596"]: 
+            # NOTE: probably shouldn't do it this way
+            # TODO: find specific tag
             if any(tex_name.endswith(id) for id in ["1167", "1077", "1461", "1596"]):
                 material.blend_method = 'BLEND'
                 material.node_tree.links.new(node_1.outputs["Color"], material.node_tree.nodes['Principled BSDF'].inputs["Alpha"])
@@ -1200,7 +1195,6 @@ class Material(DataStruct):
             material.node_tree.links.new(node_1.outputs["Color"], material.node_tree.nodes['Principled BSDF'].inputs["Base Color"])
             return material
     
-    # TODO: cleanup
     def unmake(self, mesh):
         #find if the mesh has an image texture
         self.detect_skybox()
@@ -1209,7 +1203,6 @@ class Material(DataStruct):
             material = slot.material
             if material:
                 material_name = material.name #.split(".")[0]
-                #self.id = material_name
                 self.id = material_name[data_name_prefix_len:]
                 if material_name in self.model.materials:
                     return self.model.materials[material_name]
@@ -1518,7 +1511,7 @@ class Mesh(DataStruct):
                         
                 new_faces.append(new_face)
 
-            #TODO check if node has vertex group
+            # TODO: check if node has vertex group
             if False:
                 self.group_parent = None
                 self.group_count = None
@@ -2169,7 +2162,7 @@ class ModelData():
         for d in self.data:
             d.make()
     def unmake(self):
-        #TODO only get objects from collection
+        # TODO: only get objects from collection
         for obj in bpy.data.objects:
             if obj.type == 'LIGHT' and obj.data.LStr:
                 self.data.append(LStr(self, self.model).unmake(obj))

--- a/swe1r/modelblock.py
+++ b/swe1r/modelblock.py
@@ -25,7 +25,7 @@ import math
 import mathutils
 from .general import RGB3Bytes, FloatPosition, FloatVector, DataStruct, RGBA4Bytes, ShortPosition, FloatMatrix, writeFloatBE, writeInt32BE, writeString, writeUInt32BE, writeUInt8, readString, readInt32BE, readUInt32BE, readUInt8, readFloatBE
 from .textureblock import Texture
-from .general import data_name_format, data_name_prefix_len
+from .general import data_name_format, data_name_prefix_len, data_name_format_long
 from ..popup import show_custom_popup
 from ..utils import find_existing_light
 
@@ -1102,7 +1102,7 @@ class Material(DataStruct):
     # TODO: cleanup
     def make(self):
         #mat_name = str(self.id)
-        mat_name = data_name_format.format(data_type = 'mat', label = str(self.id))
+        mat_name = data_name_format_long.format(data_type = 'mat', group_id = '{:03d}'.format(self.model.id), label = str(self.id))
         if (self.texture is not None):
             material = bpy.data.materials.get(mat_name)
             if material is not None:

--- a/swe1r/textureblock.py
+++ b/swe1r/textureblock.py
@@ -25,7 +25,6 @@ from ..utils import euclidean_distance
 from .modelblock import DataStruct
 from .general import data_name_format
 
-# TODO: cleanup
 class Texture():
     def __init__(self, id, format = 513, width = 32, height = 32):
         if(int(id) == 65535):
@@ -56,7 +55,6 @@ class Texture():
             print(f"Texture {self.id} is missing width/height/format data")
             return
         tex_name = data_name_format.format(data_type = 'tex', label = str(self.id))
-        #new_image = bpy.data.images.new(str(self.id), self.width, self.height)
         new_image = bpy.data.images.new(tex_name, self.width, self.height)
         image_pixels = []    
         pixels = self.pixels.data
@@ -157,7 +155,7 @@ class Palette():
             threshold = 16 if int(image['format']) == 512 else 256
         pixels = image.pixels
         
-        #TODO replace with color quantization solution
+        # TODO: replace with color quantization solution
         for i in range(0, len(pixels), 4):
             color = RGBA5551().from_array([ int(j*255) for j in pixels[i: i+4]])
             if not color in self.data:

--- a/swe1r/textureblock.py
+++ b/swe1r/textureblock.py
@@ -23,7 +23,9 @@ import struct
 import bpy
 from ..utils import euclidean_distance
 from .modelblock import DataStruct
+from .general import data_name_format
 
+# TODO: cleanup
 class Texture():
     def __init__(self, id, format = 513, width = 32, height = 32):
         if(int(id) == 65535):
@@ -53,7 +55,9 @@ class Texture():
         if None in [self.format, self.width, self.height]:
             print(f"Texture {self.id} is missing width/height/format data")
             return
-        new_image = bpy.data.images.new(str(self.id), self.width, self.height)
+        tex_name = data_name_format.format(data_type = 'tex', label = str(self.id))
+        #new_image = bpy.data.images.new(str(self.id), self.width, self.height)
+        new_image = bpy.data.images.new(tex_name, self.width, self.height)
         image_pixels = []    
         pixels = self.pixels.data
         palette = None if self.palette is None or self.palette.data is None else self.palette.data
@@ -82,6 +86,7 @@ class Texture():
         new_image['id'] = self.id
 
         return new_image
+
     def unmake(self, image):
         self.width, self.height = image.size
         self.palette = Palette(self).unmake(image)

--- a/swr_import.py
+++ b/swr_import.py
@@ -24,6 +24,7 @@ from .swe1r.modelblock import Model
 from .swe1r.splineblock import Spline
 from .swe1r.spline_map import spline_map
 from .swe1r.block import Block
+from .swe1r.general import data_name_format
 
 # for material in bpy.data.materials:
 #     material.user_clear()
@@ -41,11 +42,12 @@ from .swe1r.block import Block
 scale = 0.01
 
 def import_model(file_path, selector=None):
-    for image in bpy.data.images:
-        bpy.data.images.remove(image)
-        
-    for mat in bpy.data.materials:
-        bpy.data.materials.remove(mat)
+    # TODO: remove resources again, but following a pattern so as to avoid clashes with unrelated stuff
+    #for image in bpy.data.images:
+    #    bpy.data.images.remove(image)
+    #    
+    #for mat in bpy.data.materials:
+    #    bpy.data.materials.remove(mat)
         
     modelblock = Block(file_path + 'out_modelblock.bin', [[], []]).read()
     textureblock = Block(file_path + 'out_textureblock.bin', [[], []]).read()


### PR DESCRIPTION
Addresses the issue of all materials and images in the blender tree being deleted indiscriminately upon importing any model.

Changes
- Now only removes resources that were originally made by blender-swe1r, and are no longer needed.
- Implements special formatting to assist with managing addon-created resources.
- Notifies user when resources are removed.

In practice, removing resources at the import stage may be unnecessary, as the resource management should prevent clashes and it's easy for the user to purge unused resources manually in any case. I decided to keep it around for now as a housekeeping step for the sake of not rocking the boat too much, but you may want to consider removing this step entirely in future.